### PR TITLE
Use keywords for system names, and explicitly specify ASDF:DEFSYSTEM.

### DIFF
--- a/minion.asd
+++ b/minion.asd
@@ -1,6 +1,6 @@
 ;;;; See the LICENSE file for licensing information.
 
-(defsystem minion
+(asdf:defsystem :minion
   :name "minion"
   :author "Brian Mastenbrook"
   :version "0.1.0"
@@ -8,7 +8,7 @@
   :description "IRC bot for SBCL"
   :depends-on
   (:cl-irc :cl-ppcre :split-sequence 
-   :irc-bot drakma)
+   :irc-bot :drakma)
   :properties ((#:author-email . "cl-irc-devel@common-lisp.net")
                (#:date . "$Date: 2005/10/13 18:22:38 $")
                ((#:albert #:output-dir) . "doc/api-doc/")


### PR DESCRIPTION
Just because consistency