### PR TITLE
Drop the filler character in front of the registration URL.

### DIFF
--- a/minion/minion.lisp
+++ b/minion/minion.lisp
@@ -617,7 +617,7 @@
                               ;; These characters can be removed... we only want HH:MM+TZ to be kept
                               (until (string-trim "# " until-line))
                               (url-line (read-line s))
-                              (matches (nth-value 1 (scan-to-strings "^(\\S+)" url-line)))
+                              (matches (nth-value 1 (scan-to-strings "^.(http\\S+)" url-line)))
                               (secret-url (aref matches 0)))
                          (format nil "The URL ~s will be ~a." secret-url until))))
                    (if (scan "^(?i)hello(\\s|$)*" first-pass) "what's up?")

--- a/minion/minion.lisp
+++ b/minion/minion.lisp
@@ -619,7 +619,7 @@
                               (url-line (read-line s))
                               (matches (nth-value 1 (scan-to-strings "^.(http\\S+)" url-line)))
                               (secret-url (aref matches 0)))
-                         (format nil "The URL ~s will be ~a." secret-url until))))
+                         (format nil "The URL ~a will be ~a." secret-url until))))
                    (if (scan "^(?i)hello(\\s|$)*" first-pass) "what's up?")
                    (if (scan "^(?i)hi(\\s|$)*" first-pass) "what's up?")
                    (if (scan "^(?i)yo(\\s|$)*" first-pass) "what's up?")


### PR DESCRIPTION
What started as a way to reduce the number of lines in the apache config
now bites back.