### PR TITLE
/var/tmp/ isn't available in Apache's namespace.

### DIFF
--- a/minion/minion.lisp
+++ b/minion/minion.lisp
@@ -13,7 +13,7 @@
 
 (defvar *aliases* nil)
 
-(defparameter *registration-secret* #P"/var/tmp/.registration.secret")
+(defparameter *registration-secret* #P"/srv/lisppaste/.registration.secret")
 
 (defparameter *sd-file*
   (asdf:system-relative-pathname :minion "minion/sd.lisp-expr"))


### PR DESCRIPTION
Thanks!